### PR TITLE
Added custom policy for SQL threat detection

### DIFF
--- a/policies/sql/sql server threat detection types/azurepolicy.parameters.json
+++ b/policies/sql/sql server threat detection types/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "DeployIfNotExists"
+  }
+}

--- a/policies/sql/sql server threat detection types/azurepolicy.rules.json
+++ b/policies/sql/sql server threat detection types/azurepolicy.rules.json
@@ -17,7 +17,7 @@
         "equals": ""
       },
       "roleDefinitionIds": [
-        "/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437"
+        "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
       ],
       "deployment": {
         "properties": {
@@ -28,6 +28,9 @@
             "parameters": {
               "SQLServerName": {
                 "type": "string"
+              },
+              "location": {
+                "type": "string"
               }
             },
             "resources": [
@@ -35,6 +38,7 @@
                 "type": "Microsoft.Sql/servers/securityAlertPolicies",
                 "apiVersion": "2017-03-01-preview",
                 "name": "[concat(parameters('SQLServerName'), '/Default')]",
+                "location": "[parameters('location')]",
                 "properties": {
                   "state": "Enabled",
                   "disabledAlerts": []
@@ -45,6 +49,9 @@
           "parameters": {
             "SQLServerName": {
               "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
             }
           }
         }

--- a/policies/sql/sql server threat detection types/azurepolicy.rules.json
+++ b/policies/sql/sql server threat detection types/azurepolicy.rules.json
@@ -1,0 +1,54 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Sql/servers"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "name": "[field('name')]",
+      "existenceCondition": {
+        "field": "Microsoft.Sql/servers/securityAlertPolicies/disabledAlerts[*]",
+        "equals": ""
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "SQLServerName": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Sql/servers/securityAlertPolicies",
+                "apiVersion": "2017-03-01-preview",
+                "name": "[concat(parameters('SQLServerName'), '/Default')]",
+                "properties": {
+                  "state": "Enabled",
+                  "disabledAlerts": []
+                }
+              }
+            ]
+          },
+          "parameters": {
+            "SQLServerName": {
+              "value": "[field('name')]"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/policies/sql/sql server threat detection types/metadata.json
+++ b/policies/sql/sql server threat detection types/metadata.json
@@ -1,0 +1,9 @@
+{
+    "name": "be96ac95-0f17-444c-8c00-f22ae74c1d7c",
+    "displayName": "Ensure that 'Threat Detection types' is set to 'All' for SQL Server",
+    "description": "Ensure that 'Threat Detection types' is set to 'All' for SQL Server",
+    "mode": "All",
+    "metadata": {
+        "category": "SQL Server"
+    }
+}


### PR DESCRIPTION
Added custom azure policy definition for policy **Ensure that 'Threat Detection types' is set to 'All' for SQL Server**. This policy sets advanced data security threat detection types to all category on SQL server 